### PR TITLE
fix иконки ion-toggle, когда поле освобождается

### DIFF
--- a/src/hooks/game/lockable-fields.ts
+++ b/src/hooks/game/lockable-fields.ts
@@ -41,7 +41,7 @@ export class LockableFields {
                 if (val) {
                     btn.hide();
                     ctr.mnpl('locked', '0');
-                    btn.find('div').addClass('ion-toggle').removeClass('ion-toggle-filled');
+                    btn.find('div').addClass('ion-toggle-filled').removeClass('ion-toggle');
                     this.unlock(k);
                 } else {
                     btn.show();


### PR DESCRIPTION
Если поле освободилось или его продали (на раскладе), то ставится иконка ion-toggle, а должна быть ion-toggle-filled